### PR TITLE
fix: setup: add short sleep in minio-setup and vault-setup to avoid race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,36 @@ The various credentials are in file [env](./.env) and can be changed if you wish
 
 ## Common setup and teardown
 
-* Download the images and start the containers:
+### Setup
+
+* Download the images:
+  ```
+  $ docker compose pull
+  ```
+
+* Start the containers:
   ```
   $ docker compose up
   ```
+
+### Verify setup
+
+The docker-compose file uses some short-lived containers to perform initialization. Given the amount of log output from `docker compose up`, failures can be hard to notice.
+
+Run `docker compose ps` and confirm that the containers ending with `-setup` have exited with a `0` state. If any of them exited with a different code, then look back at the logs from `docker compose up` and identify the problem.
+
+For example:
+
+```
+$ docker compose ps | grep setup
+concourse-in-a-box_minio-setup_1   /scripts/minio-setup.sh          Exit 1
+concourse-in-a-box_vault-setup_1   /scripts/vault-setup.sh          Exit 0
+```
+
+The minio setup failed.
+
+### Teardown
+
 * When done, remember to stop the containers:
   ```
   $ docker compose stop

--- a/scripts/minio-setup.sh
+++ b/scripts/minio-setup.sh
@@ -7,6 +7,13 @@ set -e
 : "${MINIO_ACCESS_KEY?Need to set this environment variable}"
 : "${MINIO_SECRET_KEY?Need to set this environment variable}"
 
+# FIXME This should be replaced by a more robust healthcheck, see
+# https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
+# https://docs.docker.com/engine/reference/builder/#healthcheck
+echo
+echo "***** Sleeping a few seconds to allow Minio to startup"
+sleep 5
+
 echo
 echo "***** Logging in to Minio"
 mc alias set concourse-minio "$MINIO_ADDR" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"

--- a/scripts/vault-setup.sh
+++ b/scripts/vault-setup.sh
@@ -10,6 +10,13 @@ set -e
 : "${MINIO_ACCESS_KEY?Need to set this environment variable}"
 : "${MINIO_SECRET_KEY?Need to set this environment variable}"
 
+# FIXME This should be replaced by a more robust healthcheck, see
+# https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
+# https://docs.docker.com/engine/reference/builder/#healthcheck
+echo
+echo "***** Sleeping a few seconds to allow Vault to startup"
+sleep 5
+
 echo
 echo "***** Logging in to Vault"
 vault login token="$VAULT_DEV_ROOT_TOKEN_ID"


### PR DESCRIPTION
Sometimes minio is not ready when minio-setup runs.
This commit is a sort of an hack, we should investigate using `healthcheck`:
- https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
- https://docs.docker.com/engine/reference/builder/#healthcheck